### PR TITLE
feat(backend): use mythtv as the default group for mythbackend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -35,5 +35,5 @@ EXPOSE 6554/tcp
 EXPOSE 6744/tcp
 EXPOSE 1900/udp
 
-USER mythtv:39
+USER mythtv:mythtv
 CMD mythbackend

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,7 @@
 ARG UBUNTU_VERSION=noble
 FROM ubuntu:${UBUNTU_VERSION}
 
-RUN groupadd -rg 128 mythtv && useradd -ru 120 -md /home/mythtv -g mythtv mythtv && usermod -aG 39 mythtv
+RUN groupadd -rg 128 mythtv && useradd -ru 120 -md /home/mythtv -g mythtv mythtv
 ARG MYTHTV_VERSION=34
 ARG UBUNTU_VERSION=noble
 


### PR DESCRIPTION
A GID of `39` was set for the `mythbackend` container for debugging purposes, but this is no longer necessary or recommended. The builtin `mythtv` group should be used as the container's primary group; if more groups are necessary to access `/dev` nodes (e.g. tuners and transcoders), use [`--group-add`](https://docs.docker.com/reference/cli/docker/container/run/#options) (docker/podman CLI), [`group_add`](https://docs.docker.com/reference/compose-file/services/#group_add) (docker compose), or [`GroupAdd`](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html#container-units-container) (podman quadlet) to add other groups to the container.